### PR TITLE
Mapping general content update

### DIFF
--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -6,7 +6,7 @@ sidebar: auto
 Too many anime maps? Not enough anime maps?  
 Take matters into your own hands and learn to map here!
 
-::: tip NOTE  
+::: tip INFO  
 If you have feedback on how we can improve the mapping resources fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSfVS6_EMZOujxthR3lTa2eEwHg5C3x1INouLgnbHhBDpv1M5A/viewform)!  
 You can also visit `#mapping-discussion` on the BSMG Discord to get involved!
 :::

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -85,7 +85,8 @@ A suite of tools for mappers **using new format .dat files** that includes:
   * **Tempo Changer:** For those who need to change the BPM of their entire map that will correctly shift block placements 
   * **Offset Remover:** Removes editor offset and snaps notes/obstacles/events to common precisions to try and mitigate floating point error
   * **Note Sorter:** Sorts unordered notes/obstacles/events in the map file to fix stack spawning  
-* [BS Viewer](https://skystudioapps.com/bs-viewer/) by **+1 Rabbit** A convienient way to checkout how your map might look in game without the game since the lighting preview in some editors, such as MM/MMA2, are not as accurate. IOS and Safari support is pending.
+* [BS Viewer](https://skystudioapps.com/bs-viewer/) by **+1 Rabbit** A convienient way to checkout how your map might look in game without the game.  
+  * **IOS and Safari are currently not supported.**
 * [BPM Saber](https://github.com/zevdg/bpm-saber), by **Zevdg**
 A utility for mappers who need to change the BPM of their entire map that will correctly shift block placements. **Only works on old format .json files**
 * [BPM Saber](https://bsaber.com/bpmsaber/), by **Elliotttate**

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -26,7 +26,11 @@ Go from thinking about mapping to releasing your first map by following this che
 7. Once your song has been mapped, lighted, and playtested you’re ready to [release](/mapping/#publishing-songs) your song to the world on Beat Saver.
 
 ### Video Tutorials
-* [BennyDaBeast's Mapping Tutorials](https://bsaber.com/benny-custom-mapping/) **highly recommended**
+Text guides aren't your thing? Checkout these video series!
+:::tip Remember: 
+The text guides on this wiki are more up to date as it is easier and quicker to change.
+:::
+* [BennyDaBeast's Mapping Tutorials](https://bsaber.com/benny-custom-mapping/) **Recommended Series**
 ::: warning
 Benny uses an older editor called Mediocre Mapper in these tutorials. The UI and some processes have changed in the latest recommended editor, [MMA2](/mapping/mediocre-map-assistant.md) but, the rest of the content is great!
 :::
@@ -145,7 +149,7 @@ Follow these steps to test any of your maps made with a community editor using P
 2. Access your map in-game via the CustomWIPLevels category in the bottom song pack menu. Use practice mode to play (the small button next to the yellow play button).
 
 ::: tip NOTE
-You will need to have at least the core mods installed in order to see the CustomWIPLevels category.
+You will need to have the **SongCore** mod installed in order to see the CustomWIPLevels category.
 :::  
 
 ### Testing on a Quest
@@ -196,13 +200,13 @@ See the [Playtesting](/mapping/#playtesting) section for instructions.
 ### BeatSaver
 [BeatSaver](https://beatsaver.com/) is the public repository for all custom Beat Saber maps. Songs must be in the 2.0 song format (files are .dat and .ogg/.egg/.wav) to be compatible.
 
-::: danger
-The BeatSaver server is slowly dying due to increased traffic. Uploading maps will be challenging, if not impossible, until the server is replaced.
+::: danger NOTICE
+The BeatSaver server is slowly dying due to increased traffic. Uploading and deleting maps will be challenging, if not impossible, until the server is replaced.
 :::
 
 #### How to Release a Map
 
-1. [Create an account](https://beatsaver.com/auth/register) on BeatSaver.
+1. [Create an account](https://beatsaver.com/auth/register) on BeatSaver. If you are not recieving a verification email drop into `#mapping-discussion` for assistance.
 2. Click the *Upload* link in the top-right nav bar.
 3. Add your BeatSaver map name and map description. Only the map name is searchable so be sure to include song name, song artist, and other terms that might make it easier to find your map.
 ::: tip
@@ -244,4 +248,4 @@ Alternatively, since `_customData` is **NOT** a required field, you can go ahead
 To be compliant with the new schema, please also find and remove or fill in any **blank fields** in your `Info.dat` or difficulty files.
 
 ### BeastSaber
-[BeastSaber](http://www.bsaber.com) is a song review and curation site with a social side for member profiles, forums, news, and tutorials. All songs published on BeatSaver are mirrored to BeastSaber within 10-15 minutes.
+[BeastSaber](http://www.bsaber.com) is a song review and curation site with a social side for member profiles, forums, news, and tutorials. All songs published on BeatSaver are mirrored to BeastSaber within 10-15 minutes. Additionally, maps deleted from BeatSaver may take up to a day to be removed from BeastSaber.

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -62,8 +62,8 @@ A new web-based 3D beat saber editor that runs in the browser so it's platform a
 #### ChroMapper
 **Coming soon!** ChroMapper is a unity-based full-featured editor, developed by Caeden117, which is in the final rounds of bug fixing and is in closed beta. It uses the same engine as Beat Saber, which provides a much more true-to-life preview of lights and environments. ChroMapper also has stellar support for lighting and Chroma RGB.
 
-::: tip INFO
-Interested in making your own editor or converter? You may find the [SongCore readme page](https://github.com/Kylemc1413/SongCore/blob/master/README.md) and [this Pastebin](https://pastebin.com/cTPGrxWY) helpful!
+::: tip Interested in making your own editor or converter?
+You may find the [SongCore readme page](https://github.com/Kylemc1413/SongCore/blob/master/README.md) and [this Pastebin](https://pastebin.com/cTPGrxWY) helpful!
 :::
 
 ### Official Editor 
@@ -106,14 +106,18 @@ To apply for the **Mapper** role on the Beat Saber Modding Group discord you mus
 ### Modding & Ranking
 Maps that meet specific [Ranking Criteria](https://docs.google.com/document/d/1mtVihRO1LomyptXayoDNDTQYgX_TQPp6ZYDmtwR2jMI/edit) and go through an intensive review process called “modding” have the potential to become ranked, awarding players Performance Points (PP) toward global leaderboards. More information and an in-depth FAQ is available on the [ScoreSaber Discord](https://discord.gg/WpuDMwU)
 
-* Prior to requesting ranking, mappers should thoroughly review the ranking criteria and [metadata standards](https://docs.google.com/document/d/1ehotupIYMVlc8x41JldO-24m7Am-oTVYnciF9KCRdNM/edit) and have their map modded by a knowledgeable source. *Want an even more detailed look? Review the [Ranking Team Handbook](https://docs.google.com/document/d/18sT1CEVc-Do_kpAs567BdeJqWSzT9xazp20biA9Th0o/edit?usp=sharing) for some of the more ambiguous ranking considerations.*
+* Prior to requesting ranking, mappers should thoroughly review the ranking criteria and [metadata standards](https://docs.google.com/document/d/1ehotupIYMVlc8x41JldO-24m7Am-oTVYnciF9KCRdNM/edit) and have their map modded by a knowledgeable source. 
+:::tip Want an even more detailed look? 
+Review the [Ranking Team Handbook](https://docs.google.com/document/d/18sT1CEVc-Do_kpAs567BdeJqWSzT9xazp20biA9Th0o/edit?usp=sharing) for some of the more ambiguous ranking considerations.
+:::
 * Once your map has been modded and revised, it’s ready to be submitted via the ScoreSaber Discord for review by the ranking team (which involves additional rounds of strict modding and revision).
 * If a ranking team member deems the map acceptable it will be added to the ranking request queue to be voted on by the full ranking team.
 
 ## Lighting Practices
 A map is not considered complete without some form of lighting included. Lighting can range from very basic to incredibly detailed using additional mods to enable more features.
 
-* [**Basic Lighting**](/mapping/basic-lighting.md) - Info on how to easily light your maps manually
+* [**Basic Lighting**](/mapping/basic-lighting.md) - Learn the various aspects to lighting your map manually!
+* **Advanced Lighting** - Satsified with making simple lights? Learn more advanced techniques!
 
 Below are additional lighting resources as we migrate over to the wiki pages.
 
@@ -122,8 +126,7 @@ Below are additional lighting resources as we migrate over to the wiki pages.
 * [Using Flash & Fade Lighting Events](https://bsaber.com/creating-lighting-how-flash-fade-notes-actually-work-in-game/) by ManDynasty
 * [Side Laser Speed Reference](https://docs.google.com/spreadsheets/d/1tIERmSyFI4ssjDkE-oJjBBvUZUJ7eoVhCQyM3_BsJwE/edit?usp=sharing) by LittleAsi
 
-**Lightmap**
-Lightmap is integrated into Mediocre Map Assistant 2. It can be accessed in the error checker menu.
+**Lightmap** is an automated way to add lights to your map and is integrated into Mediocre Map Assistant 2 and can be accessed in the error checker menu. Keep in mind that it is not that hard to create simple manual lighting that is better at expressing the atmosphere of the song than lightmap.
 
 ## Playtesting
 Testing your work is a critical part of mapping. Playing your own maps as you work helps you adjust for major playability issues and get a feel for your map. Third-party or “outside” playtesting is when someone other than yourself tests your pre-release map and provides constructive feedback and is helpful in highlighting issues to which you may be "map blind."
@@ -172,7 +175,7 @@ The `#testplays` channel in the Beat Saber Modding Group discord makes it easy t
 * Delete the testplay posting! 
 :::
 
-You can copy and paste the following code into Discord:
+You can copy and paste the following template into Discord:
 ```
 **Map:**
 **Length:**

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -86,7 +86,7 @@ A suite of tools for mappers **using new format .dat files** that includes:
   * **Offset Remover:** Removes editor offset and snaps notes/obstacles/events to common precisions to try and mitigate floating point error
   * **Note Sorter:** Sorts unordered notes/obstacles/events in the map file to fix stack spawning  
 * [BS Viewer](https://skystudioapps.com/bs-viewer/) by **+1 Rabbit** A convienient way to checkout how your map might look in game without the game.  
-  * **IOS and Safari are currently not supported.**
+  * IOS and Safari are currently not supported.
 * [BPM Saber](https://github.com/zevdg/bpm-saber), by **Zevdg**
 A utility for mappers who need to change the BPM of their entire map that will correctly shift block placements. **Only works on old format .json files**
 * [BPM Saber](https://bsaber.com/bpmsaber/), by **Elliotttate**
@@ -122,7 +122,7 @@ Review the [Ranking Team Handbook](https://docs.google.com/document/d/18sT1CEVc-
 A map is not considered complete without some form of lighting included. Lighting can range from very basic to incredibly detailed using additional mods to enable more features.
 
 * [**Basic Lighting**](/mapping/basic-lighting.md) - Learn the various aspects to lighting your map manually!
-* **Advanced Lighting** - Satsified with making simple lights? Learn more advanced techniques!
+* **Advanced Lighting** - Satsified with making simple lights? Learn more advanced techniques! (coming soon... ask in #mapping-discussion if you want more info!)
 
 Below are additional lighting resources as we migrate over to the wiki pages.
 
@@ -146,7 +146,7 @@ You **do not** need to upload your map to Beat Saver in order for you or anyone 
 ### Testing on a PC
 Follow these steps to test any of your maps made with a community editor using PC-based VR.
 
-1. If your WIP song folder isn’t already in Beat Saber_Data\CustomWIPLevels then place a copy there.
+1. If your WIP song folder isn’t already in `Beat Saber_Data\CustomWIPLevels` then place a copy there.
 2. Access your map in-game via the CustomWIPLevels category in the bottom song pack menu. Use practice mode to play (the small button next to the yellow play button).
 
 ::: tip NOTE
@@ -160,6 +160,10 @@ Follow these steps to test any of your maps made with a community editor using a
 2. Drag and drop the .zip file onto the BMBF upload window.
 3. Click <kbd>Sync to Beat Saber</kbd>.
 4. Access your map in-game via the CustomWIPLevels category in the bottom song pack menu. Use practice mode to play (the small button next to the yellow play button).
+
+:::tip
+If after deleting an old copy of a map and reuploading it with a new version on a quest still results with the old version being played, rename the zip file before uploading it through bmbf.
+:::
 
 ### Community / Third Party Testing
 The `#testplays` channel in the Beat Saber Modding Group discord makes it easy to have your work checked by knowledgeable mappers. Playtesters will provide constructive feedback on how to improve your map in either video or text format in a DM or in the `#mapping-discussion` channel.

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -36,6 +36,8 @@ See the [Advanced Audio Editing](/mapping/advanced-audio.md) page for more in-de
 There are three ways to find the BPM for the song which you want to map. Try them in order (easiest to hardest) if you don't get any results:
 
 ### Tool-Assisted BPM Calculation
+> This is the recommended method for songs with a constant BPM
+
 [Arrow Vortex](https://arrowvortex.ddrnl.com/) is a free tool to analyze a song’s BPM automatically. It will also find the offset needed to line the audio up to the beat in Audacity or your map editor. Ryger’s [Arrow Vortex BPM Analysis Tutorial](https://youtu.be/Z49UKFefu5c) includes both BPM detection and confirmation. After finding the BPM and offset values you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
 
 If the website download does not work, a mirror download is available [here.](https://cdn.discordapp.com/attachments/443569023951568906/662417326771273728/ArrowVortex.zip)

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -35,11 +35,13 @@ See the [Advanced Audio Editing](/mapping/advanced-audio.md) page for more in-de
 ## Finding the BPM
 There are three ways to find the BPM for the song which you want to map. Try them in order (easiest to hardest) if you don't get any results:
 
-### Online Search
-You can search online using a search engine site (e.g. [Google](http://google.com)) in your web browser for `[song name] + [artist] + "bpm"` and often find a number of sites (e.g. [SongBPM.com](https://songbpm.com/)) with this information.
-
 ### Tool-Assisted BPM Calculation
 [Arrow Vortex](https://arrowvortex.ddrnl.com/) is a free tool to analyze a song’s BPM automatically. It will also find the offset needed to line the audio up to the beat in Audacity or your map editor. Ryger’s [Arrow Vortex BPM Analysis Tutorial](https://youtu.be/Z49UKFefu5c) includes both BPM detection and confirmation. After finding the BPM and offset values you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
+
+If the website download does not work, a mirror download is available [here.](https://cdn.discordapp.com/attachments/443569023951568906/662417326771273728/ArrowVortex.zip)
+
+### Online Search
+You can search online using a search engine site (e.g. [Google](http://google.com)) in your web browser for `[song name] + [artist] + "bpm"` and often find a number of sites (e.g. [SongBPM.com](https://songbpm.com/)) with this information.
 
 ### Manual BPM Calculation
 If both methods above fail you will have to manually find the BPM, but this is easier than you might think.

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -28,7 +28,7 @@ Follow these general guidelines as you work on your maps:
 * A close second are high bitrate (+200kbps) **MP3 or AAC** files (lossy formats). 
 * Use a YouTube rip **only** as a last resort. The bitrate is low and the volume is seldom right. In this case some audio editing might be required (see [Editing with Audacity](/mapping/basic-audio.html#editing-with-audacity)).
 
-> Often an artist’s [Bandcamp](https://bandcamp.com/) or sites where you can buy the tracks/album will have the highest quality source available.
+> Sites where you can buy the tracks/album, such as an artist’s [Bandcamp](https://bandcamp.com/), usually will have the highest quality source available.
 
 See the [Advanced Audio Editing](/mapping/advanced-audio.md) page for more in-depth techniques and tools for analysing the audio quality of files.
 

--- a/wiki/mapping/basic-lighting.md
+++ b/wiki/mapping/basic-lighting.md
@@ -179,7 +179,7 @@ If you choose to add custom colors to your map this must be the LAST thing you d
 ## Previewing Your Lights
 These tools will help PC Beat Saber users preview their lighting more accurately. Most editors do not show true-to-life lighting effects.
  
-### FPFC
+### In-game with FPFC
 First Person Flying Controller (FPFC) is a launch parameter that can be used by either Steam or Oculus users. You will need the [FPFCToggle](https://cdn.discordapp.com/attachments/441819897941458944/654983047250182144/FPFCToggle.dll) and [Music Escape](https://cdn.discordapp.com/attachments/441819897941458944/655236882715770910/MusicEscape.dll) mods, available through the #pc-mods channel on the BSMG discord. FPFC will open an instance of BeatSaver on your desktop and allow you to control it with your keyboard and mouse.
 
 `FPFCToggle` allows you to use WASD to "fly" around in your map. `Music Escape` allows you to exit your level by hitting the <kbd>ESC</kbd> key (otherwise you must play your song to completion.
@@ -190,3 +190,6 @@ First Person Flying Controller (FPFC) is a launch parameter that can be used by 
 1. Right click on Beat Saber.exe and create a shortcut. 
 2. Edit the Target to add "fpfc" to the end of it.
 For example: `C:\Program Files\Oculus\Software\Software\hyperbolic-magnetism-beat-saber\Beat Saber.exe" fpfc`
+
+### Online with BS Viewer
+[BS Viewer](https://skystudioapps.com/bs-viewer/) by **+1 Rabbit** is an online tool that is a convienient way to checkout how your map might look in game without the game. Just upload your map zip to the website and preview! Unfortunately **IOS and Safari are currently not supported.**

--- a/wiki/mapping/basic-lighting.md
+++ b/wiki/mapping/basic-lighting.md
@@ -38,7 +38,7 @@ It's impossible to control the duration of a fade out or use a fade in with stan
 ~ Skeelie
 
 
-Lighting truly is a an art which means that it's much more subjective than mapping. There are relatively few best practices to get started and simple manual lighting is almost impossible to do poorly.
+Lighting truly is an art which means that it's much more subjective than mapping. There are relatively few best practices to get started and simple manual lighting is almost impossible to do poorly.
 
 ::: warning NOTE  
 Lighting previews are not realistic in the editors currently available to the public so it’s important to preview your lights in-game often. See [Previewing Your Lights](/mapping/basic-lighting.html#previewing-your-lights) for some tools that can help.

--- a/wiki/mapping/basic-mapping.md
+++ b/wiki/mapping/basic-mapping.md
@@ -6,6 +6,9 @@ next: ./intermediate-mapping.md
 # Basic Mapping
 _If you are a new mapper, read this page from top to bottom. Every word. Every picture. This page will give you all the info and best practices you need to make a solid first map!_
 
+Many thanks to contributors from across the mapping community who made this expanded wiki possible!
+* [Glossary of Terms](/mapping/glossary.md)
+
 ## Ready to Map?
 **Have you…**
 1. [x] [Downloaded Audacity](https://www.audacityteam.org/) and chosen a [map editor](/mapping#map-editing-resources)?


### PR DESCRIPTION
Lots of small content and formatting changes. 
The commits after the first should detail their changes.

The changes in ad856e4 are
Outlining the interested in making a mapper block better
Moving the more detailed look section for ranked into a tip box
Rephrase the basic lighting desc and added advanced lighting text that is not linked
Expanded lightmap description and nudge to manual lighting
Rephrase the testplay format from "code" to "template" 