### PR TITLE
Cleaning up spelling/broken link and update mma2 troubleshooting

### DIFF
--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -11,7 +11,6 @@ If you have feedback on how we can improve the mapping resources fill out this [
 You can also visit `#mapping-discussion` on the BSMG Discord to get involved!
 :::
 
-Over *thirty* different mapping guides and tutorials have been combined into this wiki so that it can be maintained by the community as a whole. Many many **MANY** thanks to the mappers who blazed this trail and contributed content including **Awfulnaut, BennyDaBeast, Bloodcloak, Checkthepan, Cyan Snow, Freeek, The Good Boi, Helen Carnate, Hexagonial, Kolezan, LittleAsi, Megalon, MandyNasty, Nik, Puds, Ris, Ryger, Scrappy, Silent Caay, Skyler Wallace, Sykes,** and **Uninstaller.**
 * [Mapping Term Glossary](/mapping/glossary.md)
 
 ## Mapping Quick Start
@@ -21,7 +20,7 @@ Go from thinking about mapping to releasing your first map by following this che
 2. [Set up your audio file](/mapping/#audio-editing-resources) including finding and confirming the BPM and exporting to OGG format. 
 3. Set up your first song in your mapping editor (steps vary by editor but here's the [user guide](/mapping/mediocre-map-assistant.html) for MMA2).
 4. Get mapping! Review [basic mapping practices](/mapping/basic-mapping.html) before you start. [Playtest](/mapping/#playtesting) your own work early and often while mapping.
-5. Get lighting! Review [basic lighting information](/mapping/#lighting-practices). Simple manual lighting is easier than you think!
+5. Get lighting! Review [basic lighting information](/mapping/basic-lighting.html). Simple manual lighting is easier than you think!
 6. Get your map [playtested](/mapping/#playtesting)! Third-party playtesting via the BSMG Discord is highly recommended to get constructive feedback and to get past your own “map blindness.”
 7. Once your song has been mapped, lighted, and playtested you’re ready to [release](/mapping/#publishing-songs) your song to the world on Beat Saver.
 
@@ -254,3 +253,6 @@ To be compliant with the new schema, please also find and remove or fill in any 
 
 ### BeastSaber
 [BeastSaber](http://www.bsaber.com) is a song review and curation site with a social side for member profiles, forums, news, and tutorials. All songs published on BeatSaver are mirrored to BeastSaber within 10-15 minutes. Additionally, maps deleted from BeatSaver may take up to a day to be removed from BeastSaber.
+
+## Credits
+Over *thirty* different mapping guides and tutorials have been combined into this wiki so that it can be maintained by the community as a whole. Many many **MANY** thanks to the mappers who blazed this trail and contributed content including **Awfulnaut, BennyDaBeast, Bloodcloak, Checkthepan, Cyan Snow, Freeek, The Good Boi, Helen Carnate, Hexagonial, Kolezan, LittleAsi, Megalon, MandyNasty, Nik, Puds, Ris, Ryger, Scrappy, Silent Caay, Skyler Wallace, Sykes,** and **Uninstaller.**

--- a/wiki/mapping/basic-lighting.md
+++ b/wiki/mapping/basic-lighting.md
@@ -180,7 +180,7 @@ If you choose to add custom colors to your map this must be the LAST thing you d
 These tools will help PC Beat Saber users preview their lighting more accurately. Most editors do not show true-to-life lighting effects.
  
 ### In-game with FPFC
-First Person Flying Controller (FPFC) is a launch parameter that can be used by either Steam or Oculus users. You will need the [FPFCToggle](https://cdn.discordapp.com/attachments/441819897941458944/654983047250182144/FPFCToggle.dll) and [Music Escape](https://cdn.discordapp.com/attachments/441819897941458944/655236882715770910/MusicEscape.dll) mods, available through the #pc-mods channel on the BSMG discord. FPFC will open an instance of BeatSaver on your desktop and allow you to control it with your keyboard and mouse.
+First Person Flying Controller (FPFC) is a launch parameter that can be used by either Steam or Oculus users. You will need the [FPFCToggle](https://cdn.discordapp.com/attachments/441819897941458944/654983047250182144/FPFCToggle.dll) and [Music Escape](https://cdn.discordapp.com/attachments/441819897941458944/655236882715770910/MusicEscape.dll) mods, available through the #pc-mods channel on the BSMG discord. FPFC will open an instance of Beat Saber on your desktop and allow you to control it with your keyboard and mouse.
 
 `FPFCToggle` allows you to use WASD to "fly" around in your map. `Music Escape` allows you to exit your level by hitting the <kbd>ESC</kbd> key (otherwise you must play your song to completion.
 

--- a/wiki/mapping/basic-mapping.md
+++ b/wiki/mapping/basic-mapping.md
@@ -47,7 +47,7 @@ When you’re ready to prepare your song for upload you must have a minimum of f
 
 **A few notes about bombs:**
 * Bomb hitboxes are smaller than block hitboxes, smaller even than the bomb model itself
-* Bombs are hard to see when there are no lighting events active. Make sure your map isn’t dark when bombs are coming up. See [Basic Lighting](link) for more tips.
+* Bombs are hard to see when there are no lighting events active. Make sure your map isn’t dark when bombs are coming up. See [Basic Lighting](/mapping/basic-lighting.html) for more tips.
 * Bombs are disabled once they have passed the player
 
 ### Block Distribution

--- a/wiki/mapping/mediocre-map-assistant.md
+++ b/wiki/mapping/mediocre-map-assistant.md
@@ -66,7 +66,9 @@ The settings pane includes global settings for autosaving, zip packaging, folder
 * **Legacy Settings:** If you have the Chroma mod installed you can check this box to enable the Chroma lighting toolbar but it has been unsupported for some time.
 * **Other Settings:** Click the <kbd>Clear Settings</kbd> button to revert to default settings. You may also enter new paths for either of your song folders. If for some reason nothing works you can click the <kbd>Everything Inexplicably Broken?</kbd> button to delete your config file.
 
-> TIP Double check to make sure that the paths you entered at setup are showing up under the "Songs" and "WIP Songs" fields. Add them if they are missing.
+::: warning
+Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
+:::
 
 ## Song Setup
 Once you've finished one-time editor setup you're ready to create your first map. 
@@ -108,7 +110,7 @@ On the right side of the `Song Info` page is the area where you create individua
 1. Click the **<kbd>Add Difficulty</kbd>** button. The default difficulty is easy
 2. In the **Difficulty** dropdown select which difficulty you want to make (easy, normal, hard, expert, or expertplus)
 3. In the **Characteristic** dropdown you can select Standard, No Arrows, or Single Saber.
-4. **Difficulty Label** is optional and allows you to give your difficulties custom names in-game, *This feature may not reliably work on all VR models*
+4. **Difficulty Label** is optional and allows you to give your difficulties custom names in-game. If left blank, the difficulty set in the dropdown will be displayed instead. *This feature may not reliably work on all VR models*
 5. The **Start Offset (ms)** field is where you entered an offset value, in milliseconds, if needed based on the way you [setup your audio file](https://bsmg.wiki/mapping/basic-audio.html)
 6. The **Note Jump Speed** field is where you change the speed at which the notes move down the track. Click into the field for a pop-up of helpful information. See [Basic Mapping Practices](/mapping/basic-mapping.html#gauging-difficulty-down-mapping) for guidance on setting an appropriate NJS for your difficulty.
 7. The **Spawn Distance Modifier** field allows you to adjust how far down the track your blocks appear. Changing this value will adjust the "jump distance" guidance pop-up
@@ -209,8 +211,17 @@ Hover over the **NPS** value to see the difficulty ranges for OST1 tracks. See t
 | ![Stats panel screenshot](./images/mma2-stats-panel.png) | **Notes:** The total number of notes in your map<br />**Notes per Second:** The number of notes in your map divided by the number of seconds in your map. This number isn’t accurate until you’ve finished mapping, unless you've only selected a small section.<br />**Bombs, Walls, and Lighting:** The number of each event you have in your map.<br />**R/B Ratio:** If you have exactly the same number of red and blue blocks this will be 1.00. Greater than 1 you have more reds. Less than 1 you have more blues.<br />**Vision Blocks:** The percentage of your map’s blocks that are vision blocks at 0.75 beats. Use the vision block checker to correct.<br />**Aggressive Vision Blocks:** The percentage of your map’s blocks that are vision blocks at 1.25 beats. Useful for faster songs.<br />**Top/Middle/Bottom Notes:** The percentage of your blocks that are placed in each row. |
 
 ## Troubleshooting
+**ISSUE: Create Level button does nothing even if a song name is entered**  
+RESOLUTION: Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
+
 **ISSUE: My song is stuck loading in the editor forever**<br />
-RESOLUTION: This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder.
+RESOLUTION: This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder. Usage of convert to OGG websites is the common cause of this issue.
 
 **ISSUE: I can't figure out how to place dot notes**<br />
 RESOLUTION: Press <kbd>ESC</kbd> and review the in-editor list of keybindings or consult the list of [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing). HINT: It's `F`
+
+**ISSUE: One Saber maps don't load in game**  
+RESOLUTION: Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "One Saber",` and replace with `"_beatmapCharacteristicName": "OneSaber",`
+
+**ISSUE: No Arrows maps don't load in game**  
+RESOLUTION: Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "No Arrows",` and replace with `"_beatmapCharacteristicName": "NoArrows",`


### PR DESCRIPTION
Mapping Home: 
- Update lighting link in quick start
- Move credits to bottom of page

Basic Mapping: 
- Fix link to basic lighting

Basic Lighting: 
- Fix typo in FPFC section incorrectly stating beatsaver instead of beat saber

MMA2 User Guide: 
- Note known bug for wip path not carried over after first time setup 
- Difficulty label being optional with the default behavior noted
- One Saber and No Arrows bug resolutions added
- add common cause of no or long loading from edit menu