### PR TITLE
More updates and cleaning to mapping

### DIFF
--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -227,28 +227,28 @@ Encountered something not listed here? Drop into `#mapping-discussion` for assis
 
 **Something went wrong! Try again later.**   
   This is the default error message, causes include:  
-  **>>** An upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
-  **>>** Illegal characters are present in a map file. Make sure your metadata and bookmarks don't contain special characters. [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
+  * An upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
+  * Illegal characters are present in a map file. Make sure your metadata and bookmarks don't contain special characters. [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
 
 **Field `._customData._customEnviroment` cannot be blank.**  
-  **>>** Your files are not compliant the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  
+  * Your files are not compliant the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  
 
 **Beatmap zip contains an illegal file!**  
-  **>>** Usually caused by extra/unsupported files, such as gifs, in the zip.  
+  * Usually caused by extra/unsupported files, such as gifs, in the zip.  
 
 **Beatmap already exists!**  
-  **>>** The exact map files were uploaded previously. You must change something small in your map (i.e., remove a light block, save the map, replace the light block, and save again) to be able to upload.  
+  * The exact map files were uploaded previously. You must change something small in your map (i.e., remove a light block, save the map, replace the light block, and save again) to be able to upload.  
 
 **Beatmap does not contain an info.dat file!**  
-  **>>** Usually caused by having the files in a subfolder. You need to zip the files instead of the folder. [How to Video](https://streamable.com/u20ci) Or use the handy export button in your editor instead. **NOTE: MMA2's export button does not include contributor images in the zip.**  
+  * Usually caused by having the files in a subfolder. You need to zip the files instead of the folder. [How to Video](https://streamable.com/u20ci) Or use the handy export button in your editor instead. **NOTE: MMA2's export button does not include contributor images in the zip.**  
 
 **One or more beatmap difficulty files cannot be found!**  
-  **>>** You might have forgotten to include all of your difficultiy files are in the zip.  
-  **>>** A difficulty's `"_beatmapFilename"` in the `info.dat` might be using a different file name than what is present in the folder.  
-  **>>** A deleted difficulty is still being referenced in your `info.dat` file. Check to make sure you do not have unintended difficulties in the `"_difficultyBeatmaps"` cluster of each present characteristc.  
+  * You might have forgotten to include all of your difficultiy files are in the zip.  
+  * A difficulty's `"_beatmapFilename"` in the `info.dat` might be using a different file name than what is present in the folder.  
+  * A deleted difficulty is still being referenced in your `info.dat` file. Check to make sure you do not have unintended difficulties in the `"_difficultyBeatmaps"` cluster of each present characteristc.  
 
 **Beatmap could not be parsed!**  
-  **>>** This could be caused by extreme server load. Try again later or ask in `#mapping-discussion`.  
+  * This could be caused by extreme server load. Try again later or ask in `#mapping-discussion`.  
 
 #### BeatSaver Data Schema Change - October 27, 2019
 BeatSaver now enforces a schema in order for your maps to be uploaded, of which public MediocreMapper is not compliant with. The most breaking change happened in the difficulty data files, where MM-specific fields were moved inside a `_customData` object.

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -59,8 +59,8 @@ A 3D editor that runs in the browser, allowing anyone with a web browser to map.
 * [BeatMapper Website](https://beatmapper.app/)
 * [BeatMapper User Manual](https://beatmapper.app/docs/manual/getting-started)
 
-#### ChroMapper (*coming soon)
-A full-featured editor that is currently in closed beta. ChroMapper shares similar assets with Beat Saber, so the visuals match better. It also has stellar support for lighting and Chroma RGB.
+#### ChroMapper - *Coming Soon*
+A 3D editor that has stellar support for lighting, Chroma RGB, and shares similar assets with Beat Saber, allowing for a more accurate preview. ChroMapper is currently in closed beta with no planned public release date.
 
 ::: tip Interested in making your own editor or converter?
 You may find the [SongCore readme page](https://github.com/Kylemc1413/SongCore/blob/master/README.md) and [the Beatmap Schemas](https://github.com/lolPants/beatmap-schemas/tree/master/schemas) helpful!
@@ -223,19 +223,25 @@ Map files cannot currently be updated on BeatSaver. If you need to upload a new 
 
 ### BeatSaver Troubleshooting
 Here are solutions for some common errors when uploading a Beatmap.  
-Encountered something not listed here? Drop into `#mapping-discussion` for assistance.
-  - **Something went wrong! Try again later.**  
-    Usually caused by an upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.
-  - **Field `._customData._customEnviroment` cannot be blank.**  
-    This is caused by using an editor not compliant with the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.
-  - **Beatmap zip contains an illegal file!**  
-    Usually caused by extra/unsupported files, such as gifs, in the zip.
-  - **Beatmap already exists!**  
-    The exact map files were uploaded previously. You must change something small in your map (i.e., remove a light block, save the map, replace the light block, and save again) to be able to upload.
-  - **Beatmap does not contain an info.dat file!**  
-    Usually caused by having the files in a subfolder. You need to zip the files instead of the folder. [How to Video](https://streamable.com/u20ci) Or use the handy export button in your editor instead. **NOTE: MMA2's export button does not include contributor images in the zip.**
-  - **Beatmap could not be parsed!**  
-    This could be caused by extreme server load. Try again later or ask in `#mapping-discussion`.
+Encountered something not listed here? Drop into `#mapping-discussion` for assistance. 
+
+**Something went wrong! Try again later.**   
+  **>>** Usually caused by an upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
+
+**Field `._customData._customEnviroment` cannot be blank.**  
+  **>>** This is caused by using an editor not compliant with the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  
+
+**Beatmap zip contains an illegal file!**  
+  **>>** Usually caused by extra/unsupported files, such as gifs, in the zip.  
+
+**Beatmap already exists!**  
+  **>>** The exact map files were uploaded previously. You must change something small in your map (i.e., remove a light block, save the map, replace the light block, and save again) to be able to upload.  
+
+**Beatmap does not contain an info.dat file!**  
+  **>>** Usually caused by having the files in a subfolder. You need to zip the files instead of the folder. [How to Video](https://streamable.com/u20ci) Or use the handy export button in your editor instead. **NOTE: MMA2's export button does not include contributor images in the zip.**  
+
+**Beatmap could not be parsed!**  
+  **>>** This could be caused by extreme server load. Try again later or ask in `#mapping-discussion`.  
 
 #### BeatSaver Data Schema Change - October 27, 2019
 BeatSaver now enforces a schema in order for your maps to be uploaded, of which public MediocreMapper is not compliant with. The most breaking change happened in the difficulty data files, where MM-specific fields were moved inside a `_customData` object.

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -228,7 +228,7 @@ Encountered something not listed here? Drop into `#mapping-discussion` for assis
 **Something went wrong! Try again later.**   
   This is the default error message, causes include:  
   **>>** An upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
-  **>>** Illegal characters are present in a map file. [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
+  **>>** Illegal characters are present in a map file. Make sure your metadata and bookmarks don't contain special characters. [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
 
 **Field `._customData._customEnviroment` cannot be blank.**  
   **>>** Your files are not compliant the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -226,10 +226,12 @@ Here are solutions for some common errors when uploading a Beatmap.
 Encountered something not listed here? Drop into `#mapping-discussion` for assistance. 
 
 **Something went wrong! Try again later.**   
-  **>>** Usually caused by an upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
+  This is the default error message, causes include:  
+  **>>** An upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
+  **>>** Illegal characters are present in a map file. [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
 
 **Field `._customData._customEnviroment` cannot be blank.**  
-  **>>** This is caused by using an editor not compliant with the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  
+  **>>** Your files are not compliant the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  
 
 **Beatmap zip contains an illegal file!**  
   **>>** Usually caused by extra/unsupported files, such as gifs, in the zip.  
@@ -239,6 +241,11 @@ Encountered something not listed here? Drop into `#mapping-discussion` for assis
 
 **Beatmap does not contain an info.dat file!**  
   **>>** Usually caused by having the files in a subfolder. You need to zip the files instead of the folder. [How to Video](https://streamable.com/u20ci) Or use the handy export button in your editor instead. **NOTE: MMA2's export button does not include contributor images in the zip.**  
+
+**One or more beatmap difficulty files cannot be found!**  
+  **>>** You might have forgotten to include all of your difficultiy files are in the zip.  
+  **>>** A difficulty's `"_beatmapFilename"` in the `info.dat` might be using a different file name than what is present in the folder.  
+  **>>** A deleted difficulty is still being referenced in your `info.dat` file. Check to make sure you do not have unintended difficulties in the `"_difficultyBeatmaps"` cluster of each present characteristc.  
 
 **Beatmap could not be parsed!**  
   **>>** This could be caused by extreme server load. Try again later or ask in `#mapping-discussion`.  

--- a/wiki/mapping/advanced-audio.md
+++ b/wiki/mapping/advanced-audio.md
@@ -6,7 +6,6 @@ next: false
 # Advanced Audio Editing
 _Diving deeper into audio editing_
 
-**Content in this section is derived from original guides by n3tman and LittleAsi, edited by Kolezan. Many thanks to contributors from across the mapping community who made this expanded wiki possible!**
 * [Glossary of Terms](/mapping/glossary.md)
 
 On this page you will find additional guides and resources for better understanding audio or more advanced techniques of editing audio.
@@ -141,3 +140,6 @@ There are several methods to go about handling variable BPM:
 * Manually time the BPM changes in MedicoreMapper. [Video tutorial by BennyDaBeast here](https://www.youtube.com/watch?v=6AwR4SeaiHU).
 * Use a DAW software and find all the tempo changes using a tempo track editor. Use Jumps instead of Ramps as that’s how MediocreMapper changes tempo. When you’ve found all the tempo changes input those into MediocreMapper. (Remember, DAW softwares usually display measures and beats, but MediocreMapper only displays beats.)
 * Use a DAW software and time warp the sound into a fixed BPM. This, however, could introduce artifacts or warp the sound and could be more easily noticeable by listeners/players.
+
+## Credits
+Content in this section is derived from guides by **n3tman** and **LittleAsi**, edited by **Kolezan**.

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -6,8 +6,6 @@ next: ./advanced-audio.md
 # Basic Audio Setup
 _Get your audio file set up and ready for mapping_
 
-**Content in this section is derived from original guides by Kolezan & Nik.**  
-Many thanks to contributors from across the mapping community who made this expanded wiki possible!
 * [Glossary of Terms](/mapping/glossary.md)
 
 This page provides both new and experienced mappers with general recommendations for setting up a new song file before starting to map. Review the quick start guide below for steps that are **critical** before you begin mapping vs. those that can be done at any time, if they're needed.
@@ -282,3 +280,6 @@ The song/audio file is now ready to be used in any map editor. Input the same BP
 ::: warning NOTE
 Audio file should not be larger than ~14 MB due to the BeatSaver 15 MB ZIP file limit. If this is the case export at a lower quality until the file meets the file size limit. ZIP files over 8 MB cannot be shared directly on Discord (without Nitro) for playtesting.
 :::
+
+## Credits
+Content on this page is derived from guides by **Kolezan** & **Nik**.

--- a/wiki/mapping/basic-audio.md
+++ b/wiki/mapping/basic-audio.md
@@ -57,18 +57,24 @@ This is the recommended method for songs with a constant BPM
 These steps are the same as those used in Ryger’s [Arrow Vortex BPM Analysis Tutorial](https://youtu.be/Z49UKFefu5c) (which also includes BPM confirmation). 
 1. Download [Arrow Vortex](https://arrowvortex.ddrnl.com/) (AV), extract the file, and open `ArrowVortex.exe`
 	- If the website download does not work, a mirror download is available [here.](https://cdn.discordapp.com/attachments/443569023951568906/662417326771273728/ArrowVortex.zip)
-2. Drag your song file into the AV window
-3. Go to the `View` menu and click `Time based (C-mod)` to see the waveform
-	1. Use <kbd>CTRL</kbd> + mouse scroll to zoom
-4. Go to the `Tempo` menu and click `Adjust sync...` or just press <kbd>SHIFT</kbd>+<kbd>S</kbd> to open the adjustment window.
-5. Click the <kbd>Find BPM</kbd> button
-6. If you're lucky, AV will return a single BPM value with 100% confidence. Do not round off a decimal BPM!  
+2. Export your song to `.ogg` using [Audacity](https://www.audacityteam.org/)
+	* Using other formats (ie. `.mp3` or `.m4a`) adds a delay to the audio that varies every time and is not accounted for when you export your changes for use in editor.
+3. Drag the song file into the AV window
+4. Go to the `View` menu and click `Time based (C-mod)` to see the waveform
+	* Use <kbd>CTRL</kbd> + mouse scroll to zoom
+5. Go to the `Tempo` menu and click `Adjust sync...` or just press <kbd>SHIFT</kbd>+<kbd>S</kbd> to open the adjustment window.
+6. Click the <kbd>Find BPM</kbd> button
+7. If you're lucky, AV will return a single BPM value with 100% confidence. Do not round off a decimal BPM!  
 ![AV adjustment window](./images/adjustments.png)
-7. Click the <kbd>Apply BPM</kbd> button
-8. Press <kbd>F3</kbd> to turn on beat ticks to confirm that the beginning, middle, and end of your track are all lined up
-9. Give the player about two seconds to get ready by clicking the `Move first beat` button ![Arrow Vortex move beat button](./images/av_movebeat.png) however many times needed to get your offset close to 2.000.
-	1. **Note:** If your song already has enough intro silence, you only need to add enough beats to make your offset positive.
-10. After finding the BPM and offset values you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
+8. Click the <kbd>Apply BPM</kbd> button
+9. Press <kbd>F3</kbd> to turn on beat ticks to confirm that the beginning, middle, and end of your track are all lined up
+10. Give the player about two seconds to get ready by clicking the `Move first beat` button ![Arrow Vortex move beat button](./images/av_movebeat.png) however many times needed to get your offset close to 2.000.
+	* **Note:** If your song already has enough intro silence, you only need to add enough beats to make your offset positive.
+11. After finding the BPM and offset values you can skip to [Add Silence: After Tool Assisted Sync](/mapping/basic-audio.html#after-tool-assisted-sync).
+
+:::warning
+Not using a `.ogg` file or using the export feature in AV will desync your song by an inconsistent amount of milliseconds.
+:::
 
 ### Online Search
 You can search online using a search engine site (e.g. [Google](http://google.com)) in your web browser for `[song name] + [artist] + "bpm"` and often find a number of sites (e.g. [SongBPM.com](https://songbpm.com/)) with this information.

--- a/wiki/mapping/basic-lighting.md
+++ b/wiki/mapping/basic-lighting.md
@@ -6,11 +6,9 @@ next: false
 # Basic Lighting
 _Make Beat Saber a brighter place by manually lighting your maps_
 
-**Content in this section was authored by LittleAsi and Kolezan or derived from original guides by Puds and MandyNasty.**  
-Many thanks to contributors from across the mapping community who made this expanded wiki possible!
 * [Glossary of Terms](/mapping/glossary.md)
 ---
-Every map needs to have lighting of some sort. Once you know the tools at your disposal, simplistic manual lighting can be very easy. [This link](https://streamable.com/s/x7zj0/vrugyj) is a video example of very simple manual lighting  (note: it does use [forced custom colors](/mapping/basic-lighting.html#environment-colors)). You don't need to be an AaltopahWi or a Skeelie to make great lighting!
+Every map needs to have lighting of some sort. Once you know the tools at your disposal, simplistic manual lighting can be very easy. [This link](https://streamable.com/s/x7zj0/vrugyj) is a video example of very simple manual lighting  (Note: The example uses [Map Color Overrides](/mapping/basic-lighting.html#map-color-overrides)). You don't need to be an AaltopahWi or a Skeelie to make great lighting!
 
 ## Lighting Types
 The available lighting types are consistent across each of the built-in game environments, though they may be in slightly different positions or not present in some cases.
@@ -118,24 +116,29 @@ If you choose to add a different default environment to your map via file editin
 
 > **NOTE:** You cannot use a custom platform in this field. This will be covered in Intermediate Lighting (coming soon!)
 
-## Environment Colors
-::: tip NOTE
-Setting custom colors is an **optional**, and somewhat more advanced step. If you're not comfortable editing your `.dat` files then skip this for now.
+## Map Color Overrides
+Beat Saber v1.4 allows users to set the Red/Green/Blue (RGB) colors of notes, lights, and walls for their game. With these overrides, Mappers can force their own color scheme in-game as long as the user has the SongCore mod installed and the `Enable Custom Song Colors` option is enabled.
+
+:::tip 
+When choosing color overrides for the notes. It is **HIGHLY** recommended that you keep reddish/warm colors on the left and blueish/cold colors on the right to avoid confusing players.
 :::
 
-BeatSaber v1.4 allowed users to set the Red/Green/Blue (RGB) colors of notes, lights, and walls for their game. Mappers can "force" colors in their maps with a little bit of JSON/dat editing. As long as the user has the SongCore mod installed and the `Enable Custom Song Colors` option enabled the map will be played with the colors you set.
+[BeatMapper](/mapping/#beatmapper-app) and [ChroMapper](/mapping/#chromapper-coming-soon) natively support color overrides. Check their respective guides for more information.  
+[MMA2](/mapping/#mediocre-map-assistant-2) does not support color overrides and requires manual editing of your map files or use of [BeatMapperTools](https://mappers.beatmappertools.com/) by **Darkuni**.
 
+### Manually Adding Color Overrides
 1. Decide what RGB colors you want notes and/or lights and/or walls to be. Use a color scheme utility like [Paletton](https://paletton.com/#uid=1000u0kllllaFw0g0qFqFg0w0aF) to find complimentary colors.
-	1. **It is HIGHLY recommended that you keep reddish/warm colors on the left and blueish/cold colors on the right to avoid confusing players.**
-	2. Your red, green, and blue values will need to be converted from the normal 0-255 scale to the 0-1 scale. Use a site like [EasyRGB](https://www.easyrgb.com/en/convert.php) to convert your values.
+	* Your red, green, and blue values will need to be converted from the normal 0-255 scale to the 0-1 scale. Use a site like [EasyRGB](https://www.easyrgb.com/en/convert.php) to convert your values.
 2. Open your `info.dat` file in the text editor of your choice
 2. Scroll down to the `"_customData": {` section.
 3. Paste whichever code blocks below correspond to the colors you want to force within the `_customData` curly brackets (`{` and `}`) then replace the `"r":`, `"g":`, and `"b":` values with whatever you chose in Step 1.
-	1. The `"r":` and `"g":` values *must* have commas after them.
-	2. See lines 17-41 of this [Pastebin clip](https://pastebin.com/x9zEiHxR) for an example of these code blocks in action in a `.DAT` file.
+	* The `"r":` and `"g":` values **must** have commas after them.
 
-::: danger
-If you choose to add custom colors to your map this must be the LAST thing you do before releasing. If you open your map in the editor again after adding colors they will be erased.
+See lines 17-41 of this [Pastebin clip](https://pastebin.com/x9zEiHxR) for an example of these code blocks in action in a `.DAT` file.
+
+::: danger WARNING for MMA2 Users
+If you choose to manualy add color overrides to your map this must be the **LAST** thing you do before releasing.  
+Opening your map in the editor again will remove your color overrides.
 :::
 
 **Left Side Block Color (default Red)**
@@ -195,3 +198,6 @@ For example: `C:\Program Files\Oculus\Software\Software\hyperbolic-magnetism-bea
 
 ### Online with BS Viewer
 [BS Viewer](https://skystudioapps.com/bs-viewer/) by **+1 Rabbit** is an online tool that is a convienient way to checkout how your map might look in game without the game. Just upload your map zip to the website and preview! Unfortunately **IOS and Safari are currently not supported.**
+
+## Credits
+Content in this section was authored by **LittleAsi** and **Kolezan** or derived from guides by **Puds** and **MandyNasty**. 

--- a/wiki/mapping/basic-mapping.md
+++ b/wiki/mapping/basic-mapping.md
@@ -6,7 +6,6 @@ next: ./intermediate-mapping.md
 # Basic Mapping
 _If you are a new mapper, read this page from top to bottom. Every word. Every picture. This page will give you all the info and best practices you need to make a solid first map!_
 
-Many thanks to contributors from across the mapping community who made this expanded wiki possible!
 * [Glossary of Terms](/mapping/glossary.md)
 
 ## Ready to Map?

--- a/wiki/mapping/glossary.md
+++ b/wiki/mapping/glossary.md
@@ -4,8 +4,6 @@ sidebar: auto
 # Mapping Glossary
 _From Arrow Block to Wrist Reset and everything in between. Learn mapping lingo here!_
 
-**Many thanks to contributors from across the mapping community who have made this expanded wiki possible!**
-
 ::: tip NOTE
 This glossary is a living, breathing, growing work in progress. If there's a term you've come across not listed, let us know in #mapping-discussion!
 :::

--- a/wiki/mapping/mediocre-map-assistant.md
+++ b/wiki/mapping/mediocre-map-assistant.md
@@ -21,12 +21,12 @@ It is **VERY** important to unzip the file in step 2 as not doing so will cause 
 ### First Time Setup
 The first time you run MMA2 you will need to direct it to the location of two folders: `CustomLevels` and `CustomWIPLevels`. You have several options available to you:
 
-**If you have VR and Beat Saber:**
+**If you have the Steam or Oculus version installed on the computer:**
 * Give MMA2 the path to the two appropriate folders
 * Steam Example: `C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\CustomLevels`
 * Oculus Example: `C:\Program Files\Oculus\Software\Software\hyperbolic-magnetism-beat-saber\Beat Saber_Data\CustomWIPLevels`
 
-**If you don't have VR or Beat Saber -OR- have VR but don’t have Beat Saber:**
+**If you have the Quest version -OR- don’t have Beat Saber installed on the computer:**
 * Make two folders called `CustomLevels` and `CustomWIPLevels`
 * Example: `C:\Users\Helen\Documents\CustomWIPLevels`
 <p align="center">

--- a/wiki/mapping/mediocre-map-assistant.md
+++ b/wiki/mapping/mediocre-map-assistant.md
@@ -235,17 +235,17 @@ Hover over the **NPS** value to see the difficulty ranges for OST1 tracks. See t
 
 ## Troubleshooting
 **Create Level button does nothing even if a song name is entered**  
-**>>** Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
+* Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
 
 **My song is stuck loading in the editor forever**  
-**>>** This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder. Usage of convert to OGG websites is the common cause of this issue.  
-**>>** Forgetting to unzip the application folder (MMA2.zip) before running the program will also cause this issue.
+* This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder. Usage of convert to OGG websites is the common cause of this issue.  
+* Forgetting to unzip the application folder (MMA2.zip) before running the program will also cause this issue.
 
 **I can't figure out how to place dot notes**  
-**>>** Press <kbd>ESC</kbd> and review the in-editor list of keybindings or consult the list of [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing). HINT: It's `F`
+* Press <kbd>ESC</kbd> and review the in-editor list of keybindings or consult the list of [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing). HINT: It's `F`
 
 **One Saber maps don't load in game**  
-**>>** Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "One Saber",` and replace with `"_beatmapCharacteristicName": "OneSaber",`
+* Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "One Saber",` and replace with `"_beatmapCharacteristicName": "OneSaber",`
 
 **No Arrows maps don't load in game**  
-**>>** Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "No Arrows",` and replace with `"_beatmapCharacteristicName": "NoArrows",`
+* Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "No Arrows",` and replace with `"_beatmapCharacteristicName": "NoArrows",`

--- a/wiki/mapping/mediocre-map-assistant.md
+++ b/wiki/mapping/mediocre-map-assistant.md
@@ -4,7 +4,7 @@ sidebar: auto
 # Mediocre Map Assistant User Guide
 _Essential information to get up and running using Mediocre Map Assistant 2_
 
-::: warning NOTE
+::: tip NOTE
 This guide currently supports both [Mediocre Map Assistant 2](https://github.com/Assistant/MediocreMapAssistant2/releases/latest) by Assistant and Mediocre Mapper Mk5 (final public release) by Squeaksies. All future public development will occur on MMA2.
 :::
 
@@ -13,6 +13,10 @@ This guide currently supports both [Mediocre Map Assistant 2](https://github.com
 1. Download MMA2.zip from [GitHub](https://github.com/Assistant/MediocreMapAssistant2/releases/latest) 
 2. Unzip the file and place the extracted folder wherever you like on your hard drive.
 3. Double click `mediocremapassistant2.exe` to run.
+
+::: warning 
+It is **VERY** important to unzip the file in step 2 as not doing so will cause issues with map creation and editing!
+:::
 
 ### First Time Setup
 The first time you run MMA2 you will need to direct it to the location of two folders: `CustomLevels` and `CustomWIPLevels`. You have several options available to you:
@@ -161,10 +165,12 @@ Mapping settings can be accessed by clicking the hamburger menu in the top right
 * **<kbd>Apply Move:</kbd>** This button will commit the note movement specified above
 * **<kbd>Make/Delete Bookmark</kbd>**: This button will add a bookmark at the current cursor placement if one doesn't exist (add a name and hit enter to save) or will delete an existing bookmark
 * **<kbd>Set Preview Start at Cursor</kbd>**: This button allows you to quickly reset the beginning of your in-game music preview at the cursor location
+
 ## Basic Controls
 There are usually multiple ways to accomplish the same action, however, the keyboard shortcuts at the link below are the most efficient.
 
 * [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing)
+* To get the lighting menu, press <kbd>Tab</kbd> while editing the map.
 
 ## Error Checker
 The **Error Checker** functionality is one of the top quality of life features found in MMA2. Access the error checker by clicking <kbd>SHIFT+TAB</kbd> to check for vision blocks, double directionals, stacked notes, and view map stats.
@@ -228,17 +234,18 @@ Hover over the **NPS** value to see the difficulty ranges for OST1 tracks. See t
 | ![Stats panel screenshot](./images/mma2-stats-panel.png) | **Notes:** The total number of notes in your map<br />**Notes per Second:** The number of notes in your map divided by the number of seconds in your map. This number isn’t accurate until you’ve finished mapping, unless you've only selected a small section.<br />**Bombs, Walls, and Lighting:** The number of each event you have in your map.<br />**R/B Ratio:** If you have exactly the same number of red and blue blocks this will be 1.00. Greater than 1 you have more reds. Less than 1 you have more blues.<br />**Vision Blocks:** The percentage of your map’s blocks that are vision blocks at 0.75 beats. Use the vision block checker to correct.<br />**Aggressive Vision Blocks:** The percentage of your map’s blocks that are vision blocks at 1.25 beats. Useful for faster songs.<br />**Top/Middle/Bottom Notes:** The percentage of your blocks that are placed in each row. |
 
 ## Troubleshooting
-**ISSUE: Create Level button does nothing even if a song name is entered**  
-RESOLUTION: Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
+**Create Level button does nothing even if a song name is entered**  
+**>>** Confirm both folder paths are complete on the Song Selection screen and add the path(s) from [First Time Setup](/mapping/mediocre-map-assistant.html#first-time-setup) if blank. There is a known bug that deletes the CustomWIPLevels folder path on first use.
 
-**ISSUE: My song is stuck loading in the editor forever**<br />
-RESOLUTION: This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder. Usage of convert to OGG websites is the common cause of this issue.
+**My song is stuck loading in the editor forever**  
+**>>** This error is usually caused by a missing, corrupted, or invalid audio file. Re-read [Basic Audio Setup](/mapping/basic-audio.html) to ensure you've exported everything correctly and make sure that your file is in the correct folder. Usage of convert to OGG websites is the common cause of this issue.  
+**>>** Forgetting to unzip the application folder (MMA2.zip) before running the program will also cause this issue.
 
-**ISSUE: I can't figure out how to place dot notes**<br />
-RESOLUTION: Press <kbd>ESC</kbd> and review the in-editor list of keybindings or consult the list of [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing). HINT: It's `F`
+**I can't figure out how to place dot notes**  
+**>>** Press <kbd>ESC</kbd> and review the in-editor list of keybindings or consult the list of [Hotkey Shortcuts for All Editors](https://docs.google.com/spreadsheets/d/1iZLs80IH-KXeXE3NcNQA5kcc591XgAT-BUK6vZXcPAs/edit?usp=sharing). HINT: It's `F`
 
-**ISSUE: One Saber maps don't load in game**  
-RESOLUTION: Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "One Saber",` and replace with `"_beatmapCharacteristicName": "OneSaber",`
+**One Saber maps don't load in game**  
+**>>** Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "One Saber",` and replace with `"_beatmapCharacteristicName": "OneSaber",`
 
-**ISSUE: No Arrows maps don't load in game**  
-RESOLUTION: Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "No Arrows",` and replace with `"_beatmapCharacteristicName": "NoArrows",`
+**No Arrows maps don't load in game**  
+**>>** Open the map's info.dat in a text editor and find the line `"_beatmapCharacteristicName": "No Arrows",` and replace with `"_beatmapCharacteristicName": "NoArrows",`

--- a/wiki/mapping/mediocre-map-assistant.md
+++ b/wiki/mapping/mediocre-map-assistant.md
@@ -21,7 +21,7 @@ It is **VERY** important to unzip the file in step 2 as not doing so will cause 
 ### First Time Setup
 The first time you run MMA2 you will need to direct it to the location of two folders: `CustomLevels` and `CustomWIPLevels`. You have several options available to you:
 
-**If you have the Steam or Oculus version installed on the computer:**
+**If you have Beat Saber installed on the computer:**
 * Give MMA2 the path to the two appropriate folders
 * Steam Example: `C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\CustomLevels`
 * Oculus Example: `C:\Program Files\Oculus\Software\Software\hyperbolic-magnetism-beat-saber\Beat Saber_Data\CustomWIPLevels`


### PR DESCRIPTION
Advanced Audio:
- Move credits to the end

Basic Audio:
- Move Credits to the end
- Add bit on AV needing to use ogg or else audio will be desynced because of how mp3/m4a files are encoded

Basic Lighting:
- renamed and revised environment colors section to be more clear on the process and options available for overriding colors
- Moved credits to the end

Basic Mapping:
- Removed contributors thanks

Glossary: 
- Removed contributors thanks

MMA2 Guide:
 - Emphasize needing to unzip the mma2 zip from github to not encounter any issues 
- reformatted troubleshooting section to be more clean
- Add bit on how to get to the lighting menu in editor
- Clarify the first time setup options to more explicitly mention quest

Map Home:
- Revised CM listing to be more clear and easy to update when it releases
-  reformatted troubleshooting section to be more clean
- Beatsaver troubleshooting section changes
  - Another possible error for Something went wrong! Try again later. and note that it is the default message
  - Add info for One or more beatmap difficulty files cannot be found!
  - Made Field cannot be blank error more generic