### PR TITLE
Minor Content Update

### DIFF
--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -38,8 +38,8 @@ Benny and Freeek use older editors in their tutorials (Mediocre Mapper and EditS
 ## Audio Editing Resources
 Before mapping, you need to get your audio file ready so that it works with your map editor. This section will walk you through how to set up and edit your audio file using a free program called [Audacity](https://www.audacityteam.org/).
 
-* [**Basic Audio Setup**](/mapping/basic-audio.md)
-* [**Advanced Audio Editing**](/mapping/advanced-audio.md)
+* [**Basic Audio Setup**](/mapping/basic-audio.md) - Can't make a map without audio. Learn how to setup your audio for easy mapping!
+* [**Advanced Audio Editing**](/mapping/advanced-audio.md) - A deeper dive in adjusting audio files such as making shorter versions or working with variable BPM.
 
 ## Map Editing Resources
 

--- a/wiki/mapping/advanced-audio.md
+++ b/wiki/mapping/advanced-audio.md
@@ -163,7 +163,8 @@ This is a critical step! **You can ruin your audio if you do not set the initial
 
 4) Turn off Snap To Grid. It’s the green magnet icon in the top left corner.
 5) Add your audio to the project. Insert > Media File, and find your song.
-6) Drag the whole audio track so that the first beat’s peak lands several beats into the track. Place it exactly on a beat line marker. This prevents a hot start in game allows your song offset to be 0 in the map editor.  
+6) Drag the whole audio track accordingly to prevent a hot start or too-long of an intro. 
+   * See [Basic Audio: Plan Your First Note](/mapping/basic-audio.html#plan-your-first-note) for more info.  
 ![Align Audio Start in Reaper](./images/reaperFirstBeat.png)
 
 #### Lining Up Beats

--- a/wiki/mapping/basic-mapping.md
+++ b/wiki/mapping/basic-mapping.md
@@ -52,7 +52,7 @@ Special characters in languages such as, Japanese (日本語/にほんご), Chin
 **A few notes about bombs:**
 * Bomb hitboxes are smaller than block hitboxes, smaller even than the bomb model itself
 * Bombs are hard to see when there are no lighting events active. Make sure your map isn’t dark when bombs are coming up. See [Basic Lighting](/mapping/basic-lighting.html) for more tips.
-* Bombs are disabled once they have passed the player
+* Bombs can still be hit once they have passed the player.
 
 ### Block Distribution
 As a *very general* rule of thumb for new mappers, blocks should be distributed roughly as follows:


### PR DESCRIPTION
Advanced Audio:
- Revised step 6 in Warping with Reaper getting started to point to basic mapping plan first note instead of general adjusting audio

Basic Mapping: 
- Corrected note on bombs that players can still hit them when they pass the player

Map Home: 
- Added Descriptions to the audio editing resources as a summary and match the mapping resources format