### PR TITLE
Wiki update tracker action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,5 @@ yarn.lock             @lolpants
 # Section Owners
 /wiki/modding/**/*.md  @megalon @williums @assistant @aurosx @caeden117
 /wiki/mapping/**/*.md  @megalon @williums @assistant @helencarnate
+
+/wiki/fr/**/*.md       @Awagi

--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -1,0 +1,37 @@
+# Wiki Update Tracker, to track changes in wiki original pages, and update issues to report when a translation is required
+
+name: Wiki Update Tracker
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Get custom App JWT
+        id: get_token
+        uses: machine-learning-apps/actions-app-token@0.21
+        with:
+          APP_PEM: ${{ secrets.APP_PEM }}
+          APP_ID: ${{ secrets.APP_ID }}
+
+      - name: Check original pages status and update issues
+        uses: Awagi/wiki-update-tracker@v1.0
+        with:
+          repo-path: $GITHUB_WORKSPACE
+          original-path: "wiki"
+          ignored-paths: "wiki/LICENSE,wiki/.vuepress"
+          translation-paths: "wiki/fr"
+          file-suffix: ".md"
+          bot-label: "BOT"
+          token: ${{ steps.get_token.outputs.app_token }}
+          log-level: "DEBUG"


### PR DESCRIPTION
Changes:
- Added Wiki Update Tracker action
- Added Awagi to CODEOWNERS file for the /fr/ translation of the wiki

## Wiki Update Tracker

Awagi's [Wiki Update Tracker](https://github.com/Awagi/wiki-update-tracker) is a translation tool to keep track of changes to all of the wiki's English files.

**Features**
- Watches all wiki files for changes on master branch
- When an English wiki file is changed, creates a GitHub issue showing the changes

## Action

**Problem**
- The action needs permission to read the code and create GitHub issues.
- The default `GITHUB_TOKEN` secret provides unnecessary permissions, like the ability to write GitHub packages.
- The wiki is deployed using GitHub's package system, and we don't want to pass this token to any external apps that would be able to release their own packages.

**Solution**
- Instead of using the `GITHUB_TOKEN`, this action uses a custom GitHub App I've added to this repo that only has permission to read the code and read/write issues.
- The private key and app ID of this app is stored in the `SECRETS` for this repo, and passed to the marketplace app [Actions App Token](https://github.com/machine-learning-apps/actions-app-token) to get a custom token for the WUT to use.
- The WUT then uses this token to gain all of the permissions that the GitHub App has (read code, read/write issues).

Thanks to Awagi for writing the action file for this, I only tested it.
