### PR TITLE
📝Bump WUT release version

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -25,7 +25,7 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
 
       - name: Check original pages status and update issues
-        uses: Awagi/wiki-update-tracker@v1.0
+        uses: Awagi/wiki-update-tracker@v1.3
         with:
           repo-path: $GITHUB_WORKSPACE
           original-path: "wiki"


### PR DESCRIPTION
Bump the Wiki Update Tracker to the new version that fixes crashing with filename changes.

Tested on my own test repo.

Thanks to Awagi for updating the bot!