### PR TITLE
FR mapping supports stub page

### DIFF
--- a/wiki/fr/about/mapping-supports.md
+++ b/wiki/fr/about/mapping-supports.md
@@ -1,0 +1,7 @@
+# Mapping Supports
+
+::: danger STUB
+This page exists to fix a build error with GitHub Actions.
+
+The page has not yet been translated.
+:::


### PR DESCRIPTION
This should fix the build error with the missing mapping-supports page.