### PR TITLE
Update mapping and git workflow actions

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -11,18 +11,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip Tracking Steps?
+        if: env.ENABLE != 1
+        run: echo ENABLE_WUT Secret not set to 1, skipping page tracking... 
+
       - name: Checkout git repository
+        if: env.ENABLE == 1
         uses: actions/checkout@v2
         with:
           ref: master
           fetch-depth: 0
 
-      - name: Skip Tracking Steps?
-        if: env.ENABLE_SECRET != 1
-        run: echo ENABLE_WUT Secret not set to 1, skipping page tracking... 
-
       - name: Get custom App JWT
-        if: env.ENABLE_SECRET == 1
+        if: env.ENABLE == 1
         id: get_token
         uses: machine-learning-apps/actions-app-token@0.21
         with:
@@ -30,7 +31,7 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
 
       - name: Check original pages status and update issues
-        if: env.ENABLE_SECRET == 1
+        if: env.ENABLE == 1
         uses: Awagi/wiki-update-tracker@v1.4
         with:
           repo-path: $GITHUB_WORKSPACE
@@ -42,4 +43,4 @@ jobs:
           token: ${{ steps.get_token.outputs.app_token }}
           log-level: "DEBUG"
     env:
-        ENABLE_SECRET: ${{ secrets.ENABLE_WUT }}
+        ENABLE: ${{ secrets.ENABLE_WUT }}

--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
-    if: github.repository == 'beat-saber-modding-group/wiki'
 
     steps:
       - name: Checkout git repository
@@ -18,7 +17,12 @@ jobs:
           ref: master
           fetch-depth: 0
 
+      - name: Skip Tracking Steps?
+        if: env.ENABLE_SECRET != 1
+        run: echo ENABLE_WUT Secret not set to 1, skipping page tracking... 
+
       - name: Get custom App JWT
+        if: env.ENABLE_SECRET == 1
         id: get_token
         uses: machine-learning-apps/actions-app-token@0.21
         with:
@@ -26,6 +30,7 @@ jobs:
           APP_ID: ${{ secrets.APP_ID }}
 
       - name: Check original pages status and update issues
+        if: env.ENABLE_SECRET == 1
         uses: Awagi/wiki-update-tracker@v1.4
         with:
           repo-path: $GITHUB_WORKSPACE
@@ -36,11 +41,5 @@ jobs:
           bot-label: "BOT"
           token: ${{ steps.get_token.outputs.app_token }}
           log-level: "DEBUG"
-
-  skipTracking:
-    runs-on: ubuntu-latest
-    if: github.repository != 'beat-saber-modding-group/wiki'
-    
-    steps:
-      - name: Info - Workflow skipped
-        run: echo Current repository is not the BSMG wiki repository, skipping page tracking... 
+    env:
+        ENABLE_SECRET: ${{ secrets.ENABLE_WUT }}

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -23,12 +23,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
     - name: Skip Deploy Wiki Step?
-      if: env.ENABLE_SECRET != 1
+      if: env.ENABLE != 1
       run: echo ENABLE_CI_DEPLOY Secret not set to 1, skipping deployment... 
+
+    - name: Checkout git repository
+      if: env.ENABLE == 1      
+      uses: actions/checkout@v1
+      
     - name: Deploy Wiki
-      if: env.ENABLE_SECRET == 1
+      if: env.ENABLE == 1
       run: "curl -X POST -H 'Authorization: Bearer ${{ secrets.HOOK_TOKEN }}' -d `git rev-parse --short HEAD` '${{ secrets.HOOK_URL }}'"
     env:
-      ENABLE_SECRET: ${{ secrets.ENABLE_CI_DEPLOY }}
+      ENABLE: ${{ secrets.ENABLE_CI_DEPLOY }}

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -25,8 +25,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Skip Deploy Wiki Step?
-      if: github.repository != 'beat-saber-modding-group/wiki'
-      run: echo Current repository is not the BSMG wiki repository, skipping deployment... 
+      if: env.ENABLE_SECRET != 1
+      run: echo ENABLE_CI_DEPLOY Secret not set to 1, skipping deployment... 
     - name: Deploy Wiki
-      if: github.repository == 'beat-saber-modding-group/wiki'
+      if: env.ENABLE_SECRET == 1
       run: "curl -X POST -H 'Authorization: Bearer ${{ secrets.HOOK_TOKEN }}' -d `git rev-parse --short HEAD` '${{ secrets.HOOK_URL }}'"
+    env:
+      ENABLE_SECRET: ${{ secrets.ENABLE_CI_DEPLOY }}

--- a/wiki/mapping/README.md
+++ b/wiki/mapping/README.md
@@ -280,6 +280,7 @@ ___
   * An upload that is close to the 15 MB limit. Reduce the audio export quality slightly to make space.  
   * Unsupported characters are present in a file. Make sure your metadata and bookmarks don't contain special characters such as, Japanese (日本語/にほんご), Chinese (汉语/漢語), Arabic (اَلْعَرَبِيَّةُ‎), and accented characters (Ä/é/õ/Æ/ø/ß/Œ/Ð/ƒ).  
     * [+1 Rabbit's Mapping Tools](https://skystudioapps.com/mapping-tools/) by **+1 Rabbit** may be useful in finding the specific problem.
+  * Expired web session. If you refresh the page, you should be logged out. Login and try to upload again.
 ___
 **Field `._customData._customEnviroment` cannot be blank.**    
   * Your files are not compliant the map schema. See [Schema Change](#beatsaver-data-schema-change-october-27-2019) for solutions.  

--- a/wiki/mapping/extended-mapping.md
+++ b/wiki/mapping/extended-mapping.md
@@ -169,7 +169,7 @@ This [pastebin](https://pastebin.com/vbgFPqn9) link provides an example of a `in
 
 ### 360°/90°
 ::: warning
-It is recommended that you understand basic and intermediate mapping before stepping into 360°/90° mode mapping as it requires adapting to different mapping practices and style.
+It is recommended that you understand [basic](./basic-mapping.md) and [intermediate](./intermediate-mapping.md) mapping practices before stepping into 360°/90° mapping as it requires adapting to different mapping practices and style.
 :::
 
 360°/90° mode introduces new ways to play Beat Saber with notes spawning from different angles and direction, which opens up a lot of mapping potential and freedom as a whole.
@@ -196,6 +196,10 @@ The Lightshow characteristic is used for maps with no notes which allow players 
 * **Info.dat Name:** `Lightshow`
 
 ## 360°/90° Mapping
+
+::: warning
+It is recommended that you understand [basic](./basic-mapping.md) and [intermediate](./intermediate-mapping.md) mapping practices before stepping into 360°/90° mapping as it requires adapting to different mapping practices and style.
+:::
 
 ### Rotation Events and Values
 Two new “official” event types were introduced in v1.6.0 as part of the lighting events schema:


### PR DESCRIPTION
Add if conditional to WUT and Wiki CI Deploy Jobs to only run if on bsmg's repo and echos to note that the job was skipped due to not running on the bsmg repo.
I tested it as thoroughly as I could. It should work?

This was done so I could keep the actions running on my fork but not spam my github notifications with failed actions whenever I made a commit. Should be useful for others that forked the wiki.
___
These wiki changes were added as a test to ensure that my modifications to the workflows didn't break anything I couldn't test.

Extended Mapping:
- Modify 360/90 characteristic warning to link relevant practices pages 
- Add same warning to 360/90 section

Map Home:
- Add expired web session as cause for general beatsaver error
