### PR TITLE
New header for translation tracking

### DIFF
--- a/.github/workflows/wiki-update-tracker.yml
+++ b/.github/workflows/wiki-update-tracker.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check original pages status and update issues
         if: env.ENABLE == 1
-        uses: Awagi/wiki-update-tracker@v1.4
+        uses: Awagi/wiki-update-tracker@v1.5
         with:
           repo-path: $GITHUB_WORKSPACE
           original-path: "wiki"

--- a/wiki/fr/mapping/advanced-audio.md
+++ b/wiki/fr/mapping/advanced-audio.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: ./basic-audio.md
 next: false
+translation-done: false
 ---
 # Édition avancée de l'audio
 _Améliorer ses connaissances de l'édition d'un audio_

--- a/wiki/fr/mapping/advanced-lighting.md
+++ b/wiki/fr/mapping/advanced-lighting.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: ./basic-lighting.md
 next: false
+translation-done: false
 ---
 # Lighting avancé
 _Un résumé rapide du lighting chevronné_

--- a/wiki/fr/mapping/basic-audio.md
+++ b/wiki/fr/mapping/basic-audio.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: false
 next: ./advanced-audio.md
+translation-done: false
 ---
 # Mise en place de l'audio basique
 _Préparez votre audio pour le mapping_

--- a/wiki/fr/mapping/basic-lighting.md
+++ b/wiki/fr/mapping/basic-lighting.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: false
 next: ./advanced-lighting.md
+translation-done: false
 ---
 # Les bases du lighting
 _Un résumé rapide sur les bases du lighting_

--- a/wiki/fr/mapping/basic-mapping.md
+++ b/wiki/fr/mapping/basic-mapping.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: false
 next: ./intermediate-mapping.md
+translation-done: false
 ---
 # Les bases du mapping
 _Un résumé rapide des bases du mapping_

--- a/wiki/fr/mapping/extended-mapping.md
+++ b/wiki/fr/mapping/extended-mapping.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: ./intermediate-mapping.md
 next: false
+translation-done: false
 ---
 # Mapping étendu
 _Un résumé rapide du mapping étendu_

--- a/wiki/fr/mapping/glossary.md
+++ b/wiki/fr/mapping/glossary.md
@@ -1,5 +1,6 @@
 ---
 sidebar: auto
+translation-done: false
 ---
 # Glossaire du mapping
 

--- a/wiki/fr/mapping/intermediate-lighting.md
+++ b/wiki/fr/mapping/intermediate-lighting.md
@@ -1,4 +1,6 @@
-
+---
+translation-done: false
+---
 ::: danger
 Cette page est en cours de traduction et n'est pas viable en l'état. Veuillez vous référer à la [version originale en anglais](/mapping/intermediate-lighting.md) en attendant.
 :::

--- a/wiki/fr/mapping/intermediate-mapping.md
+++ b/wiki/fr/mapping/intermediate-mapping.md
@@ -2,6 +2,7 @@
 sidebar: auto
 prev: ./basic-mapping.md
 next: ./extended-mapping.md
+translation-done: false
 ---
 # Mapping intermédiaire
 _Un résumé rapide du mapping chevronné_

--- a/wiki/fr/mapping/mapping-credits.md
+++ b/wiki/fr/mapping/mapping-credits.md
@@ -1,4 +1,6 @@
-
+---
+translation-done: false
+---
 ::: danger
 Cette page est en cours de traduction et n'est pas viable en l'état. Veuillez vous référer à la [version originale en anglais](/mapping/mapping-credits.md) en attendant.
 :::

--- a/wiki/fr/mapping/mediocre-map-assistant.md
+++ b/wiki/fr/mapping/mediocre-map-assistant.md
@@ -1,5 +1,6 @@
 ---
 sidebar: auto
+translation-done: false
 ---
 # Guide utilisateur de Mediocre Map Assistant
 _Des informations essentielles pour partir sur des bases saines en utilisant Mediocre Map Assistant 2_

--- a/wiki/fr/modding/extras.md
+++ b/wiki/fr/modding/extras.md
@@ -1,5 +1,6 @@
 ---
 title: Compléments au modding
+translation-done: false
 ---
 # Extras
 _Les bases n'étaient pas suffisantes ? Voici des outils supplémentaires que vous pourriez utilisez !_

--- a/wiki/fr/modding/intro.md
+++ b/wiki/fr/modding/intro.md
@@ -1,3 +1,6 @@
+---
+translation-done: false
+---
 # Introduction au modding
 _Apprenez à mettre en place le modèle d'extension_
 

--- a/wiki/fr/modding/linux.md
+++ b/wiki/fr/modding/linux.md
@@ -1,3 +1,6 @@
+---
+translation-done: false
+---
 # Guide du modding sur Linux
 
 ::: danger

--- a/wiki/fr/support/new-support.md
+++ b/wiki/fr/support/new-support.md
@@ -1,5 +1,6 @@
 ---
 sidebar: auto
+translation-done: false
 ---
 # Support
 


### PR DESCRIPTION
I updated the **Wiki Update Tracker Action** to **`v1.5`**, so that it now understand a header in Markdown pages: **`translation-done`**.
Setting a page with this header tells a WUT bot to tag it as "new".

The problem before was that WUT didn't distinguish uninitialized translations and translation updates, so we had issues asking us to update 3 lines in the translation even though the 100-lines page didn't have an initialized. These issues were ambiguous and did not reflect what need to be done.

Now we can simply tell WUT when a translation page is a stub. **To do so, every stub translation pages must now have the header between the 3-dash markers**:
```yaml
---
translation-done: false
---
```

It will also give an accurate overview on finished and unfinished translations (the mapping part is pretty much not translated in French for example).

Tested on my own fork, result can be seen [here](https://github.com/Awagi/wiki/issues).

For technical review, you can see code changes [here](https://github.com/Awagi/wiki-update-tracker/compare/v1.4...v1.5).

The header doesn't break vuepress, it still successfully builds.